### PR TITLE
Added bottom margin to how-to sidebar.

### DIFF
--- a/style.css
+++ b/style.css
@@ -225,6 +225,7 @@ body {
 
 .tealwell {
   background: rgba(48, 143, 153, 0.7);
+  margin-bottom: 83px;
   border: 3px solid #0D829B; }
 
 .yellowwell {


### PR DESCRIPTION
The sidebar on the how-to page was sliding over the footer ribbon.
